### PR TITLE
PyPI does not duplicate link if the URL is named `Homepage`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,10 @@ The
 :code:`project.urls`
 section treats the key
 :code:`Home-Page`
+(or variations such as:
+:code:`home-page`,
+:code:`homepage`,
+etc),
 as a special case,
 using it as the
 :code:`Home-Page`
@@ -76,6 +80,7 @@ metadata.
 All other keys are used as
 :code:`project_urls`
 metadata.
-This does mean that specifying a home page
-will have it double linked
-from PyPI.
+If you want to avoid
+having it double-linked from PyPI
+please use
+:code:`Homepage`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,5 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 [project.urls]
-Home-Page = "https://github.com/moshez/pyproject-only-example"
+Homepage = "https://github.com/moshez/pyproject-only-example"
 Issues = "https://github.com/moshez/pyproject-only-example/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orbipatch"
-version = "2022.3.6.1"
+version = "2022.3.6.2"
 description = "silly project named after a niche math thing"
 readme = "README.rst"
 authors = [{name = "Moshe Zadka", email = "orbipatch-author@devskillup.com"}]
@@ -32,5 +32,5 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 [project.urls]
-Homepage = "https://github.com/moshez/pyproject-only-example"
+homepage = "https://github.com/moshez/pyproject-only-example"
 Issues = "https://github.com/moshez/pyproject-only-example/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orbipatch"
-version = "2022.3.6.1"
+version = "2022.3.6.2"
 description = "silly project named after a niche math thing"
 readme = "README.rst"
 authors = [{name = "Moshe Zadka", email = "orbipatch-author@devskillup.com"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orbipatch"
-version = "2022.3.6.2"
+version = "2022.3.6.1"
 description = "silly project named after a niche math thing"
 readme = "README.rst"
 authors = [{name = "Moshe Zadka", email = "orbipatch-author@devskillup.com"}]
@@ -32,5 +32,5 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 [project.urls]
-homepage = "https://github.com/moshez/pyproject-only-example"
+Homepage = "https://github.com/moshez/pyproject-only-example"
 Issues = "https://github.com/moshez/pyproject-only-example/issues"


### PR DESCRIPTION
Hi @moshez, I was just experimenting and I found out that PyPI will not duplicate the `Homepage` URL if it is written exactly like that (no dash, first letter capital).

These are the experiments: https://test.pypi.org/project/orbipatch/ 